### PR TITLE
Show the ESP-12's 3D model for the ESP-12E.

### DIFF
--- a/ESP8266.pretty/ESP-01.kicad_mod
+++ b/ESP8266.pretty/ESP-01.kicad_mod
@@ -29,9 +29,4 @@
   (pad 6 thru_hole oval (at 2.54 5.08) (size 1.7272 1.7272) (drill 1.016) (layers *.Cu *.Mask F.SilkS))
   (pad 7 thru_hole oval (at 0 7.62) (size 1.7272 1.7272) (drill 1.016) (layers *.Cu *.Mask F.SilkS))
   (pad 8 thru_hole oval (at 2.54 7.62) (size 1.7272 1.7272) (drill 1.016) (layers *.Cu *.Mask F.SilkS))
-  (model Pin_Headers.3dshapes/Pin_Header_Straight_2x04.wrl
-    (at (xyz 0.05 -0.15 0))
-    (scale (xyz 1 1 1))
-    (rotate (xyz 0 0 90))
-  )
 )

--- a/ESP8266.pretty/ESP-12E.kicad_mod
+++ b/ESP8266.pretty/ESP-12E.kicad_mod
@@ -42,4 +42,9 @@
   (pad 20 smd oval (at 16 4) (size 2.4 1.1) (layers F.Cu F.Paste F.Mask))
   (pad 21 smd oval (at 16 2) (size 2.4 1.1) (layers F.Cu F.Paste F.Mask))
   (pad 22 smd oval (at 16 0) (size 2.4 1.1) (layers F.Cu F.Paste F.Mask))
+  (model ${ESPLIB}/ESP8266.3dshapes/ESP-12.wrl
+    (at (xyz 0.04 0 0))
+    (scale (xyz 0.3937 0.3937 0.3937))
+    (rotate (xyz 0 0 0))
+  )
 )


### PR DESCRIPTION
I changed the model definition to show the 12's model for the 12E. It's not really the same, but it's better than nothing. I also cleaned up the ESP01, which doesn't have a model.
