### PR TITLE
add repo url to clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Use
 
         mkdir -p ~/kicad/libraries/
         cd ~/kicad/libraries/
-        git clone 
+        git clone https://github.com/jdunmire/kicad-ESP8266
 
  2. Add `ESP8266.lib` to the Component Libraries:
 


### PR DESCRIPTION
adds the github url to the clone command shown under Use->1. in the readme